### PR TITLE
Add GitHub metrics workflow

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,25 @@
+name: Metrics
+on:
+  schedule: [{cron: "0 * * * *"}] # Updates every hour
+  workflow_dispatch:              # Allow manual runs
+
+jobs:
+  github-metrics:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lowlighter/metrics@latest
+        with:
+          token: ${{ secrets.METRICS_TOKEN }}
+          base: ""
+          plugin: activity: yes
+          plugin: activity_limit: 5
+          plugin: activity_days: 14
+          plugin: activity_visibility: public
+          plugin: isocalendar: yes
+          plugin: habits: yes
+          plugin: activity_filter: all
+          plugin: activity_ignored: ""
+          plugin: activity_skipped: ""
+          plugin: activity_visibility: public
+          plugin: activity_tiers: yes
+          plugin: activity_languages: yes


### PR DESCRIPTION
This workflow collects GitHub metrics every hour and allows manual runs.